### PR TITLE
chore: add .env.example for easier environment setup and refine .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ JsonStorage.json
 *.pem
 *.key
 *.cnf
+
+# Azurite local storage files
+__azurite_db_*
+__blobstorage__
+__queuestorage__

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,70 @@
+# Environment variables for CodePush Server
+
+# Storage Configuration
+# Set to 'true' to use the local emulator instead of a hosted instance
+EMULATED=false
+
+# Azure Storage Configuration
+# The name of your hosted Azure storage instance
+AZURE_STORAGE_ACCOUNT=
+# The key to your Azure storage instance (if KeyVault credentials are not provided)
+AZURE_STORAGE_ACCESS_KEY=
+
+# Server Configuration
+# The URL of your server
+SERVER_URL=http://localhost:3000
+
+# GitHub OAuth Configuration
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Microsoft OAuth Configuration
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+
+# HTTPS Configuration
+# Set to 'true' to enable HTTPS for local deployment
+HTTPS=
+
+# Debugging Configuration
+# Turn on CodePush-specific logging of API and Storage requests
+LOGGING=false
+# Disable the OAuth authentication route
+DEBUG_DISABLE_AUTH=false
+# Backend id of user to behave as during the debugging session
+DEBUG_USER_ID=
+
+# Redis Configuration
+# The IP address where the Redis server is hosted
+REDIS_HOST=
+# The port which Redis is listening on
+REDIS_PORT=6379
+# The key used to authenticate requests to the Redis cache
+REDIS_KEY=
+
+# Unit Testing Configuration
+# Set to 'true' to run API unit tests against Azure storage
+TEST_AZURE_STORAGE=false
+# If TEST_AZURE_STORAGE is set to true, set to the account of the storage you would like to test on
+AZURE_STORAGE_ACCOUNT=
+# If TEST_AZURE_STORAGE is set to true, set to the access key of the storage you would like to test on
+AZURE_STORAGE_ACCESS_KEY=
+
+# Set to a Azure url to run acquisition tests against that server
+AZURE_ACQUISITION_URL=
+
+# Other Configuration
+# Set to 'true' to disable acquisition routes
+DISABLE_ACQUISITION=false
+# Set to 'true' to disable management routes
+DISABLE_MANAGEMENT=false
+# Set to 'false' in order to disable account registration
+ENABLE_ACCOUNT_REGISTRATION=true
+# Set to the max number of megabytes allowed for file uploads
+UPLOAD_SIZE_LIMIT_MB=200
+
+# To enable generating diffs for releases
+ENABLE_PACKAGE_DIFFING=false
+
+# To enable KeyVault credential resolution
+# Add any additional environment variables here

--- a/api/.env.example
+++ b/api/.env.example
@@ -50,11 +50,8 @@ REDIS_KEY=      # Redis authentication key
 # ==============================
 # Unit Testing Configuration
 # ==============================
-TEST_AZURE_STORAGE=false  # Run API unit tests against Azure storage
-AZURE_STORAGE_ACCOUNT=    # Storage account for testing (if TEST_AZURE_STORAGE=true)
-AZURE_STORAGE_ACCESS_KEY= # Storage access key for testing
-
-AZURE_ACQUISITION_URL= # URL for acquisition tests
+TEST_AZURE_STORAGE=false # Run API unit tests against Azure storage
+AZURE_ACQUISITION_URL=   # URL for acquisition tests
 
 # ==============================
 # Other Configuration

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,70 +1,74 @@
-# Environment variables for CodePush Server
+##########################################
+# Environment Variables for CodePush Server
+##########################################
 
-# Storage Configuration
-# Set to 'true' to use the local emulator instead of a hosted instance
-EMULATED=false
+# ==============================
+# Storage Configuration (REQUIRED - choose one)
+# ==============================
+EMULATED=false # Set to 'true' to use the local emulator
 
-# Azure Storage Configuration
-# The name of your hosted Azure storage instance
-AZURE_STORAGE_ACCOUNT=
-# The key to your Azure storage instance (if KeyVault credentials are not provided)
-AZURE_STORAGE_ACCESS_KEY=
+# --- Azure Storage Configuration ---
+AZURE_STORAGE_ACCOUNT=    # Azure storage account name
+AZURE_STORAGE_ACCESS_KEY= # Azure storage access key (if KeyVault not used)
 
-# Server Configuration
-# The URL of your server
-SERVER_URL=http://localhost:3000
+# ==============================
+# Server Configuration (REQUIRED)
+# ==============================
+SERVER_URL=http://localhost:3000 # The URL of your server
 
-# GitHub OAuth Configuration
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+# ==============================
+# Authentication (REQUIRED - at least one provider)
+# ==============================
 
-# Microsoft OAuth Configuration
-MICROSOFT_CLIENT_ID=
-MICROSOFT_CLIENT_SECRET=
+# --- GitHub OAuth ---
+GITHUB_CLIENT_ID=     # GitHub OAuth client ID
+GITHUB_CLIENT_SECRET= # GitHub OAuth client secret
 
-# HTTPS Configuration
-# Set to 'true' to enable HTTPS for local deployment
-HTTPS=
+# --- Microsoft OAuth ---
+MICROSOFT_CLIENT_ID=     # Microsoft OAuth client ID
+MICROSOFT_CLIENT_SECRET= # Microsoft OAuth client secret
 
-# Debugging Configuration
-# Turn on CodePush-specific logging of API and Storage requests
-LOGGING=false
-# Disable the OAuth authentication route
-DEBUG_DISABLE_AUTH=false
-# Backend id of user to behave as during the debugging session
-DEBUG_USER_ID=
+# ==============================
+# Optional Configuration
+# ==============================
 
+# --- HTTPS Configuration ---
+HTTPS= # Set to 'true' to enable HTTPS for local deployment
+
+# --- Debugging Configuration ---
+LOGGING=false            # Enable CodePush-specific logging
+DEBUG_DISABLE_AUTH=false # Disable OAuth authentication route
+DEBUG_USER_ID=           # Backend user ID for debugging session
+
+# ==============================
 # Redis Configuration
-# The IP address where the Redis server is hosted
-REDIS_HOST=
-# The port which Redis is listening on
-REDIS_PORT=6379
-# The key used to authenticate requests to the Redis cache
-REDIS_KEY=
+# ==============================
+REDIS_HOST=     # Redis server IP address
+REDIS_PORT=6379 # Redis port (default: 6379)
+REDIS_KEY=      # Redis authentication key
 
+# ==============================
 # Unit Testing Configuration
-# Set to 'true' to run API unit tests against Azure storage
-TEST_AZURE_STORAGE=false
-# If TEST_AZURE_STORAGE is set to true, set to the account of the storage you would like to test on
-AZURE_STORAGE_ACCOUNT=
-# If TEST_AZURE_STORAGE is set to true, set to the access key of the storage you would like to test on
-AZURE_STORAGE_ACCESS_KEY=
+# ==============================
+TEST_AZURE_STORAGE=false  # Run API unit tests against Azure storage
+AZURE_STORAGE_ACCOUNT=    # Storage account for testing (if TEST_AZURE_STORAGE=true)
+AZURE_STORAGE_ACCESS_KEY= # Storage access key for testing
 
-# Set to a Azure url to run acquisition tests against that server
-AZURE_ACQUISITION_URL=
+AZURE_ACQUISITION_URL= # URL for acquisition tests
 
+# ==============================
 # Other Configuration
-# Set to 'true' to disable acquisition routes
-DISABLE_ACQUISITION=false
-# Set to 'true' to disable management routes
-DISABLE_MANAGEMENT=false
-# Set to 'false' in order to disable account registration
-ENABLE_ACCOUNT_REGISTRATION=true
-# Set to the max number of megabytes allowed for file uploads
-UPLOAD_SIZE_LIMIT_MB=200
+# ==============================
+DISABLE_ACQUISITION=false        # Disable acquisition routes
+DISABLE_MANAGEMENT=false         # Disable management routes
+ENABLE_ACCOUNT_REGISTRATION=true # Enable account registration
+UPLOAD_SIZE_LIMIT_MB=200         # Max file upload size (in MB)
+ENABLE_PACKAGE_DIFFING=false     # Enable generating diffs for releases
 
-# To enable generating diffs for releases
-ENABLE_PACKAGE_DIFFING=false
-
-# To enable KeyVault credential resolution
-# Add any additional environment variables here
+# ==============================
+# Azure KeyVault Configuration (Optional)
+# ==============================
+AZURE_KEYVAULT_ACCOUNT=               # Azure KeyVault account name
+CLIENT_ID=                            # Active Directory app client ID
+CERTIFICATE_THUMBPRINT=               # AD app certificate thumbprint
+REFRESH_CREDENTIALS_INTERVAL=86400000 # Credential refresh interval (in ms, default: 1 day)

--- a/api/ENVIRONMENT.md
+++ b/api/ENVIRONMENT.md
@@ -2,7 +2,7 @@
 
 The CodePush Server is configured using environment variables.
 
-Currently, the following environment variables are available. For convenience, we will also load the server environment from any '.env' file in the api directory, and the test environment from any '.test.env' file in the root directory.
+For convenience, we will also load the server environment from any '.env' file in the api directory, and the test environment from any '.test.env' file in the root directory. Use the `.env.example` file as a template for setting up your environment variables.
 
 ## Mandatory parameters
 

--- a/api/README.md
+++ b/api/README.md
@@ -16,12 +16,26 @@ Additionally, you need to specify [EMULATED](ENVIRONMENT.md#emulated) flag equal
 
 #### Steps
 To run the CodePush Server locally, follow these steps:
-1. Clone the CodePush Service repository.
-2. Copy the `.env.example` file to a new file named `.env` in the root directory.
-3. Fill in the values for each environment variable in the `.env` file according to your development or production setup.
-4. Install dependencies by running `npm install`.
-5. Build the server by running `npm run build`.
-6. Start the server by running `npm run start:env`.
+
+1. Clone the CodePush Service repository to your local machine.
+
+2. Copy the `.env.example` file to a new file named `.env` in the root directory:
+   ````bash
+   cp .env.example .env
+   ````
+   Fill in the values for each environment variable in the `.env` file according to your development or production setup.
+3. Install all necessary dependencies:
+   ````bash
+   npm install
+   ````
+4. Compile the server code:
+   ````bash
+   npm run build
+   ````
+5. Launch the server with the environment-specific start command:
+   ````bash
+   npm run start:env
+   ````
 
 By default, local CodePush server runs on HTTP. To run CodePush Server on HTTPS:
 

--- a/api/README.md
+++ b/api/README.md
@@ -17,10 +17,11 @@ Additionally, you need to specify [EMULATED](ENVIRONMENT.md#emulated) flag equal
 #### Steps
 To run the CodePush Server locally, follow these steps:
 1. Clone the CodePush Service repository.
-1. Create a `.env` file and configure the mandatory variables as outlined in the `ENVIRONMENT.md` file.
-1. Install dependencies by running `npm install`.
-1. Build the server by running `npm run build`.
-1. Start the server by running `npm run start:env`.
+2. Copy the `.env.example` file to a new file named `.env` in the root directory.
+3. Fill in the values for each environment variable in the `.env` file according to your development or production setup.
+4. Install dependencies by running `npm install`.
+5. Build the server by running `npm run build`.
+6. Start the server by running `npm run start:env`.
 
 By default, local CodePush server runs on HTTP. To run CodePush Server on HTTPS:
 


### PR DESCRIPTION
I’ve made a couple of updates here to developer experience:
 - Added `.env.example` for easier environment setup
This provides a template for environment variables, helping developers get their local setup configured quickly.

- Updated `.gitignore` to exclude Azurite local storage files
We’ve added patterns to ignore Azurite's local storage files `(__azurite_db_*, __blobstorage__, __queuestorage__)`, keeping the working directory cleaner during local development.