### PR TITLE
Fix: Add Ignored filePath to hash-utils

### DIFF
--- a/api/script/utils/hash-utils.ts
+++ b/api/script/utils/hash-utils.ts
@@ -227,8 +227,15 @@ export class PackageManifest {
   public static isIgnored(relativeFilePath: string): boolean {
     const __MACOSX = "__MACOSX/";
     const DS_STORE = ".DS_Store";
+    const METADATA_FILE_NAME = ".codepushrelease";
 
-    return startsWith(relativeFilePath, __MACOSX) || relativeFilePath === DS_STORE || endsWith(relativeFilePath, "/" + DS_STORE);
+    return (
+      startsWith(relativeFilePath, __MACOSX) ||
+      relativeFilePath === DS_STORE ||
+      endsWith(relativeFilePath, "/" + DS_STORE) ||
+      relativeFilePath === METADATA_FILE_NAME ||
+      endsWith(relativeFilePath, "/" + METADATA_FILE_NAME)
+    );
   }
 }
 


### PR DESCRIPTION
**Fix some code on the server to support code signing.**

Currently, the server code includes `.codepushrelease`, which is a result of code signing, when calculating the package hash.
This causes a mismatch between the hash values calculated by the CLI and the server.

To resolve this, I added `.codepushrelease` to the server's isIgnored function in hash-utils.ts.