### PR TITLE
[CLI] Fix sourcemap output filename

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1326,7 +1326,7 @@ export const releaseReact = (command: cli.IReleaseReactCommand): Promise<void> =
           ? Q(command.appStoreVersion)
           : getReactNativeProjectAppVersion(command, projectName);
 
-        if (command.sourcemapOutput) {
+        if (command.sourcemapOutput && !command.sourcemapOutput.endsWith(".map")) {
           command.sourcemapOutput = path.join(command.sourcemapOutput, bundleName + ".map");
         }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1326,8 +1326,8 @@ export const releaseReact = (command: cli.IReleaseReactCommand): Promise<void> =
           ? Q(command.appStoreVersion)
           : getReactNativeProjectAppVersion(command, projectName);
 
-        if (command.outputDir) {
-          command.sourcemapOutput = path.join(command.outputDir, bundleName + ".map");
+        if (command.sourcemapOutput) {
+          command.sourcemapOutput = path.join(command.sourcemapOutput, bundleName + ".map");
         }
 
         return appVersionPromise;


### PR DESCRIPTION
**Fix sourcemapOutput Overwrite**

There's an issue where the sourcemap output is overwritten when both the sourcemap output and output directory are used together in the CLI.