### PR TITLE
Add deployment: allow specifying deployment key

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -204,6 +204,12 @@ If having a staging and production version of your app is enough to meet your ne
 code-push-standalone deployment add <appName> <deploymentName>
 ```
 
+If you want to re-use an existing deployment key, you can do this with:
+
+```
+code-push-standalone deployment add <appName> <deploymentName> -k <existing-deployment-key>
+```
+
 Just like with apps, you can remove and rename deployments as well, using the following commands respectively:
 
 ```

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -290,7 +290,7 @@ function deleteFolder(folderPath: string): Promise<void> {
 }
 
 function deploymentAdd(command: cli.IDeploymentAddCommand): Promise<void> {
-  return sdk.addDeployment(command.appName, command.deploymentName).then((deployment: Deployment): void => {
+  return sdk.addDeployment(command.appName, command.deploymentName, command.key).then((deployment: Deployment): void => {
     log(
       'Successfully added the "' +
         command.deploymentName +

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -1045,6 +1045,10 @@ export function createCommand(): cli.ICommand {
 
               deploymentAddCommand.appName = arg2;
               deploymentAddCommand.deploymentName = arg3;
+              if(argv["key"]){
+                deploymentAddCommand.key = argv["key"] as any;
+              }
+
             }
             break;
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -377,7 +377,14 @@ yargs
         yargs
           .usage(USAGE_PREFIX + " deployment add <appName> <deploymentName>")
           .demand(/*count*/ 2, /*max*/ 2) // Require exactly two non-option arguments
-          .example("deployment add MyApp MyDeployment", 'Adds deployment "MyDeployment" to app "MyApp"');
+          .example("deployment add MyApp MyDeployment", 'Adds deployment "MyDeployment" to app "MyApp"')
+          .example("deployment add MyApp MyDeployment -k abc123", 'Adds deployment key "abc123"')
+          .option("key", {
+            alias: "k",
+            demand: false,
+            description: "Specify deployment key",
+            type: "string",
+          });
 
         addCommonConfiguration(yargs);
       })

--- a/cli/script/management-sdk.ts
+++ b/cli/script/management-sdk.ts
@@ -253,8 +253,8 @@ class AccountManager {
   }
 
   // Deployments
-  public addDeployment(appName: string, deploymentName: string): Promise<Deployment> {
-    const deployment = <Deployment>{ name: deploymentName };
+  public addDeployment(appName: string, deploymentName: string, deploymentKey?: string): Promise<Deployment> {
+    const deployment = <Deployment>{ name: deploymentName, key: deploymentKey };
     return this.post(urlEncode([`/apps/${appName}/deployments/`]), JSON.stringify(deployment), /*expectResponseBody=*/ true).then(
       (res: JsonResponse) => res.body.deployment
     );

--- a/cli/script/types/cli.ts
+++ b/cli/script/types/cli.ts
@@ -107,6 +107,7 @@ export interface IDebugCommand extends ICommand {
 export interface IDeploymentAddCommand extends ICommand {
   appName: string;
   deploymentName: string;
+  key?: string;
   default: boolean;
 }
 


### PR DESCRIPTION
When migrating an existing app to the stand-alone server, it makes sense to re-use existing deployment keys.

The Rest API already allows for explicitly specifying deployment key, so this PR just adds an optional argument to the `deployment add` command.

Example usage:

```bash
code-push-standalone deployment add my-app prod existing-key-abc123
```


