### PR TITLE
Check LOGGING env-var for "true"

### DIFF
--- a/api/script/default-server.ts
+++ b/api/script/default-server.ts
@@ -90,7 +90,7 @@ export function start(done: (err?: any, server?: express.Express, storage?: Stor
         next();
       });
 
-      if (process.env.LOGGING) {
+      if (process.env.LOGGING === "true") {
         app.use((req: express.Request, res: express.Response, next: (err?: any) => void): any => {
           console.log(); // Newline to mark new request
           console.log(`[REST] Received ${req.method} request at ${req.originalUrl}`);


### PR DESCRIPTION
LOGGING env var should be exlicitly set to "true", in order to log requests. 

Currently it just needs to be truethy, which doesn't correspond with the the current default value in the example .env.local file (where it's "false"). 
Explicit "true" is also how other env-vars are checked, eg https://github.com/microsoft/code-push-server/blob/08e97d751620ad7867bb0c9b94633e94f2c01c68/api/script/default-server.ts#L110