### PR TITLE
fix: Correction of issues that are calculated when active is negative…

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -566,7 +566,9 @@ export function execute(command: cli.ICommand) {
 function getTotalActiveFromDeploymentMetrics(metrics: DeploymentMetrics): number {
   let totalActive = 0;
   Object.keys(metrics).forEach((label: string) => {
-    totalActive += metrics[label].active;
+    if (metrics[label].active > 0) {
+      totalActive += metrics[label].active;
+    }
   });
 
   return totalActive;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/852620a8-ed29-4c45-b6c6-a01ba1f4b6c8)

If the active is added even when it is negative, the total active becomes 0, so the denominator becomes 0.

![image](https://github.com/user-attachments/assets/8bdf753c-0e58-4677-b1c8-50803097ce44)

Therefore, the negative number is branched out.