### PR TITLE
Fix `parse-duration` usage in `cli`

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -5,7 +5,7 @@ import * as yargs from "yargs";
 import * as cli from "../script/types/cli";
 import * as chalk from "chalk";
 import backslash = require("backslash");
-import parseDuration = require("parse-duration");
+import parse from "parse-duration";
 
 const packageJson = require("../../package.json");
 const ROLLOUT_PERCENTAGE_REGEX: RegExp = /^(100|[1-9][0-9]|[1-9])%?$/;
@@ -1318,5 +1318,5 @@ function isDefined(object: any): boolean {
 }
 
 function parseDurationMilliseconds(durationString: string): number {
-  return Math.floor(parseDuration(durationString));
+  return Math.floor(parse(durationString));
 }


### PR DESCRIPTION
NPM package [parse-duration](https://www.npmjs.com/package/parse-duration) version was bumped from `1.1.0` to `2.1.3`  In PR #95 for CodePush CLI. This caused the build to fail with the following error:

```shell
% npm run build

> code-push-cli@0.0.1 build
> tsc

script/command-parser.ts:1321:21 - error TS2349: This expression is not callable.
  Type 'typeof import("/private/tmp/ms-code-push-server/cli/node_modules/parse-duration/index")' has no call signatures.

1321   return Math.floor(parseDuration(durationString));
                         ~~~~~~~~~~~~~


Found 1 error in script/command-parser.ts:1321
```

Changes in this PR update `parse-duration` usages in `cli/script/command-parser.ts`.