### PR TITLE
Add upper bound for parse-duration package version

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -16,7 +16,7 @@
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.29.4",
         "opener": "^1.5.2",
-        "parse-duration": "2.1.3",
+        "parse-duration": "^1.1.0",
         "plist": "^3.0.6",
         "progress": "^2.0.3",
         "prompt": "^1.3.0",
@@ -2945,9 +2945,9 @@
       }
     },
     "node_modules/parse-duration": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-2.1.3.tgz",
-      "integrity": "sha512-MtbharL7Bets65qDBXuDOHHWyY1BxTJZmJ/xGmS90iEbKE0gZ6yZpZtCda7O79GeOi/f0NwBaplIuReExIoVsw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.2.tgz",
+      "integrity": "sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==",
       "license": "MIT"
     },
     "node_modules/parseurl": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.29.4",
     "opener": "^1.5.2",
-    "parse-duration": "2.1.3",
+    "parse-duration": "^1.1.0",
     "plist": "^3.0.6",
     "progress": "^2.0.3",
     "prompt": "^1.3.0",


### PR DESCRIPTION
NPM package [parse-duration](https://www.npmjs.com/package/parse-duration) version was bumped from `1.1.0` to `2.1.3`  In PR #95 for CodePush CLI. This caused the build to fail with the following error:

```shell
% npm run build

> code-push-cli@0.0.1 build
> tsc

script/command-parser.ts:1321:21 - error TS2349: This expression is not callable.
  Type 'typeof import("/private/tmp/ms-code-push-server/cli/node_modules/parse-duration/index")' has no call signatures.

1321   return Math.floor(parseDuration(durationString));
                         ~~~~~~~~~~~~~


Found 1 error in script/command-parser.ts:1321
```

As current code-base is not compatible with `parse-duration` versions `2.0.0+`, restrict `parse-duration` to use version `1.x.y`.