### PR TITLE
fix: resolve diff file path before ending stream, add environment temp directory, and fix error when enabling diff package map

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -61,6 +61,7 @@ DISABLE_MANAGEMENT=false         # Disable management routes
 ENABLE_ACCOUNT_REGISTRATION=true # Enable account registration
 UPLOAD_SIZE_LIMIT_MB=200         # Max file upload size (in MB)
 ENABLE_PACKAGE_DIFFING=false     # Enable generating diffs for releases
+TMPDIR=./tmp                     # Temporary directory for server diff package generation
 
 # ==============================
 # Azure KeyVault Configuration (Optional)

--- a/api/script/routes/management.ts
+++ b/api/script/routes/management.ts
@@ -1286,7 +1286,7 @@ export function getManagementRouter(config: ManagementConfig): Router {
   }
 
   function processDiff(accountId: string, appId: string, deploymentId: string, appPackage: storageTypes.Package): q.Promise<void> {
-    if (!appPackage.manifestBlobUrl || process.env.ENABLE_PACKAGE_DIFFING) {
+    if (!appPackage.manifestBlobUrl || !process.env.ENABLE_PACKAGE_DIFFING) {
       // No need to process diff because either:
       //   1. The release just contains a single file.
       //   2. Diffing disabled.

--- a/api/script/utils/package-diffing.ts
+++ b/api/script/utils/package-diffing.ts
@@ -172,7 +172,7 @@ export class PackageDiffer {
                       readStreamCounter--;
                       if (readStreamCounter === 0 && !readStreamError) {
                         // All read streams have completed successfully
-                        resolve();
+                        resolve(diffFilePath);
                       }
                     });
 
@@ -185,8 +185,8 @@ export class PackageDiffer {
                     if (readStreamError) {
                       reject(readStreamError);
                     } else {
+                      resolve(diffFilePath);
                       diffFile.end();
-                      resolve();
                     }
                   }
                 });


### PR DESCRIPTION
Resolve 3 issues when enabling diffPackageMap
1. Fix: Resolve diffFilePath before ending the stream.
<img width="683" alt="image" src="https://github.com/user-attachments/assets/5d41ed53-3d3f-47ed-bc4f-7b829db84c95" />

2. Fix: Error when enabling diff package map.
<img width="675" alt="image" src="https://github.com/user-attachments/assets/29062ed7-0e1b-4380-a106-34ccbc9a8665" />

3. Add environment temp directory when diff package map is enabled.
<img width="681" alt="image" src="https://github.com/user-attachments/assets/0487ae49-bca0-4f83-a597-40d67c55d65f" />
